### PR TITLE
V1.1.0

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -40,6 +40,11 @@ require "paq" {
 "mfussenegger/nvim-lint";
 -- Status line
 "ojroques/nvim-hardline";
+-- Nvim Tree
+"nvim-tree/nvim-web-devicons";
+"nvim-tree/nvim-tree.lua";
+-- Start up screen
+"echasnovski/mini.nvim";
 }
 
 --[
@@ -193,10 +198,11 @@ vim.api.nvim_set_keymap('v', 'gP', ':Command<cr>', { noremap = true, silent = tr
 vim.api.nvim_set_keymap('n', 'gp', ':Files<cr>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('v', 'gp', ':Files<cr>', { noremap = true, silent = true })
 -- Open Explorer
-vim.api.nvim_set_keymap('n', 'go', ':Explore<cr>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('v', 'go', ':Explore<cr>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', 'gO', ':Explore .<cr>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('v', 'gO', ':Explore .<cr>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', 'go', ':NvimTreeToggle<cr>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('v', 'go', ':NvimTreeToggle<cr>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', 'gO', ':NvimTreeOpen .<cr>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('v', 'gO', ':NvimTreeOpen .<cr>', { noremap = true, silent = true })
+
 -- Open Project File search
 vim.api.nvim_set_keymap('n', 'gf', ':BLines<cr>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('v', 'gf', ':BLines<cr>', { noremap = true, silent = true })
@@ -211,6 +217,65 @@ vim.api.nvim_create_user_command('CopyRelativePath', 'let @+=expand("%")', {narg
 vim.api.nvim_create_user_command('CopyFullPath', 'let @+=expand("%:p")', {nargs = 0})
 vim.api.nvim_set_keymap('n', 'gs', '<Cmd>CopyRelativePath<CR>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('n', 'gS', '<Cmd>CopyFullPath<CR>', { noremap = true, silent = true })
+
+-- Nvim tree
+-- disable netrw at the very start of your init.lua (strongly advised)
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
+-- set termguicolors to enable highlight groups
+vim.opt.termguicolors = true
+
+-- empty setup using defaults
+require("nvim-tree").setup({
+  view = {
+    float = {
+      enable = true,
+      open_win_config = {
+        width = 80,
+      }
+    },
+    mappings = {
+        list = {
+            { key = "<ESC>", action = "close", mode = "n" }
+        }
+    }
+  },
+  update_focused_file = {
+      enable = false,
+  },
+})
+
 -- Load user customisations
 require('init-user')
 
+
+startup_actions = function()
+    return {
+            { name = 'New file', action = 'enew', section = 'Builtin actions' },
+            { name = 'Open File Explorer', action = 'NvimTreeFocus', section = 'Builtin actions' },
+            { name = 'Find File', action = 'Files', section = 'Builtin actions' },
+            { name = 'Quit Neovim', action = 'qall', section = 'Builtin actions' },
+        }
+end
+
+-- Start up
+local starter = require('mini.starter')
+starter.setup({
+    evaluate_single = true,
+    items = {
+      startup_actions(),
+      -- starter.sections.builtin_actions(),
+      -- starter.sections.recent_files(10, false),
+      starter.sections.recent_files(10, true),
+      -- Use this if you set up 'mini.sessions'
+      -- starter.sections.sessions(5, true)
+    },
+    header = 'Neovim IDE',
+    content_hooks = {
+      -- starter.gen_hook.adding_bullet(),
+      starter.gen_hook.aligning('center', 'center'),
+      starter.gen_hook.indexing('all', { 'Builtin actions'}),
+      starter.gen_hook.padding(3, 2),
+    },
+})

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -242,7 +242,7 @@ require("nvim-tree").setup({
     }
   },
   update_focused_file = {
-      enable = false,
+      enable = true,
   },
 })
 

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -252,9 +252,12 @@ require('init-user')
 
 startup_actions = function()
     return {
-            { name = 'New file', action = 'enew', section = 'Builtin actions' },
-            { name = 'Open File Explorer', action = 'NvimTreeFocus', section = 'Builtin actions' },
-            { name = 'Find File', action = 'Files', section = 'Builtin actions' },
+            { name = 'New', action = 'enew', section = 'Builtin actions' },
+            { name = 'Open', action = 'NvimTreeFocus', section = 'Builtin actions' },
+            { name = 'Project Files', action = 'Files', section = 'Builtin actions' },
+            { name = 'Commands', action = 'Command', section = 'Builtin actions' },
+            { name = 'Search', action = 'Rg', section = 'Builtin actions' },
+            { name = 'View Opened Files', action = 'Buffers', section = 'Builtin actions' },
             { name = 'Quit Neovim', action = 'qall', section = 'Builtin actions' },
         }
 end

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -57,6 +57,8 @@ vim.api.nvim_create_user_command('ReloadConfig', 'source $MYVIMRC', {nargs = 0})
 -- Editor
 --]
 vim.cmd [[set mouse=a]]
+-- spelling
+vim.cmd [[set spell]]
 -- use the systems clipboard as the default clipboard
 vim.cmd [[ set clipboard+=unnamedplus ]]
 vim.api.nvim_set_option('encoding', 'utf-8')

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -271,7 +271,7 @@ starter.setup({
       -- Use this if you set up 'mini.sessions'
       -- starter.sections.sessions(5, true)
     },
-    header = 'Neovim IDE',
+    header = 'Neovim IDE v1.1.0',
     content_hooks = {
       -- starter.gen_hook.adding_bullet(),
       starter.gen_hook.aligning('center', 'center'),

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -279,3 +279,5 @@ starter.setup({
       starter.gen_hook.padding(3, 2),
     },
 })
+
+vim.api.nvim_set_keymap('n', 'gn', ":lua require('mini.starter').open()<CR>", { noremap = true, silent = true })

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -158,14 +158,14 @@ require('hardline').setup {}
 -- Modern Text Editor Features
 --]]
 -- Selection
-vim.api.nvim_set_keymap('n', '<S-Up>', '<S-v>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<S-Down>', '<S-v>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<S-Left>', '<C-v>h', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<S-Right>', '<C-v>l', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', '<S-Up>', '<ESC><S-v>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', '<S-Down>', '<ESC><S-v>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', '<S-Left>', '<ESC><C-v>h', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', '<S-Right>', '<ESC><C-v>l', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<S-Up>', 'gh<Up>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<S-Down>', 'gh<Down>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<S-Left>', 'gh<Left>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<S-Right>', 'gh<Right>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Up>', '<ESC>gh<Up>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Down>', '<ESC>gh<Down>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Left>', '<ESC>gh<Left>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Right>', '<ESC>gh<Right>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('v', '<S-Up>', 'k', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('v', '<S-Down>', 'j', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('v', '<S-Left>', 'h', { noremap = true, silent = true })

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -217,6 +217,9 @@ vim.api.nvim_create_user_command('CopyRelativePath', 'let @+=expand("%")', {narg
 vim.api.nvim_create_user_command('CopyFullPath', 'let @+=expand("%:p")', {nargs = 0})
 vim.api.nvim_set_keymap('n', 'gs', '<Cmd>CopyRelativePath<CR>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('n', 'gS', '<Cmd>CopyFullPath<CR>', { noremap = true, silent = true })
+-- Close/Delete buffer
+vim.api.nvim_set_keymap('n', 'gx', ':bdCR>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('v', 'gx', ':bd<CR>', { noremap = true, silent = true })
 
 -- Nvim tree
 -- disable netrw at the very start of your init.lua (strongly advised)

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -267,7 +267,7 @@ starter.setup({
       startup_actions(),
       -- starter.sections.builtin_actions(),
       -- starter.sections.recent_files(10, false),
-      starter.sections.recent_files(10, true),
+      starter.sections.recent_files(9, true),
       -- Use this if you set up 'mini.sessions'
       -- starter.sections.sessions(5, true)
     },

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -158,14 +158,14 @@ require('hardline').setup {}
 -- Modern Text Editor Features
 --]]
 -- Selection
-vim.api.nvim_set_keymap('n', '<S-Up>', 'gh<Up>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<S-Down>', 'gh<Down>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<S-Left>', 'gh<Left>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<S-Right>', 'gh<Right>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', '<S-Up>', '<ESC>gh<Up>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', '<S-Down>', '<ESC>gh<Down>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', '<S-Left>', '<ESC>gh<Left>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', '<S-Right>', '<ESC>gh<Right>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<S-Up>', '<S-v>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<S-Down>', '<S-v>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<S-Left>', '<C-v>h', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<S-Right>', '<C-v>l', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Up>', '<ESC><S-v>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Down>', '<ESC><S-v>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Left>', '<ESC><C-v>h', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Right>', '<ESC><C-v>l', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('v', '<S-Up>', 'k', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('v', '<S-Down>', 'j', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('v', '<S-Left>', 'h', { noremap = true, silent = true })

--- a/KEYBINDING.md
+++ b/KEYBINDING.md
@@ -101,3 +101,6 @@ Press `SHIFT + K`.
 To copy the path of the current file (file), press `gs` to copy the relative path, press `g SHIFT + S` to get the full path.
 
 Alternatively, you can run the commands from the command bar, **CopyRelativePath** / **CopyFullPath**.
+
+## Search recently opened files
+Press `g SHIFT + P`, type `history` and press `CARRIAGE RETURN` twice.

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,7 @@ h=$HOME;
 run_command "curl -fLo $h/.local/share/nvim/site/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim";
 }
 function neovim_install_plugins {
+run_command "nvim +PaqClean +qa";
 run_command "nvim +PaqInstall +qa";
 }
 function debian_apt_update {

--- a/src/neovim/neovim_install_plugins.sh
+++ b/src/neovim/neovim_install_plugins.sh
@@ -1,3 +1,4 @@
 function neovim_install_plugins {
+run_command "nvim +PaqClean +qa";
 run_command "nvim +PaqInstall +qa";
 }


### PR DESCRIPTION
Features:

- adds a start up screen
- press `gn` to bring up starter screen (ideal for opening new or recently opened files)

![Screenshot 2022-11-13 at 23 43 14](https://user-images.githubusercontent.com/12231216/201550785-faf10990-207f-4bec-8cbf-5db6cb8ebc59.png)


- replaces Explore with nvim tree
![Screenshot 2022-11-13 at 23 45 59](https://user-images.githubusercontent.com/12231216/201550894-49f210e2-8c0c-4d62-abc6-90b51ed62d59.png)


- Improves text selection
- press 'gx' to delete/close buffer


Issues:
- User will need to install a nerd font on MacOS, and configure ITerm 2 to see icons.

Release:
This is intended for v1.1.0